### PR TITLE
feat: support grpc.max_receive/send_message_length channel options

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -188,6 +188,8 @@ pub struct GrpcCall {
     host_override: Option<String>,
     call_plugin: Option<Arc<Mutex<Option<Zval>>>>,
     cancel_token: CancellationToken,
+    max_decoding_message_size: Option<usize>,
+    max_encoding_message_size: Option<usize>,
     /// Buffered send data from a send-only startBatch (split send/recv pattern).
     pending_metadata: Vec<(String, String)>,
     pending_message: Option<Bytes>,
@@ -213,6 +215,8 @@ impl GrpcCall {
         let target = channel.get_target_uri().unwrap_or_default();
 
         let call_plugin = channel.get_call_plugin();
+        let max_decoding_message_size = channel.get_max_decoding_message_size();
+        let max_encoding_message_size = channel.get_max_encoding_message_size();
 
         Ok(Self {
             channel: tonic_channel,
@@ -221,6 +225,8 @@ impl GrpcCall {
             deadline_usec: deadline.get_usec(),
             host_override,
             call_plugin,
+            max_decoding_message_size,
+            max_encoding_message_size,
             cancel_token: CancellationToken::new(),
             pending_metadata: Vec::new(),
             pending_message: None,
@@ -404,6 +410,8 @@ impl GrpcCall {
         let method = self.method.clone();
         let deadline_usec = self.deadline_usec;
         let cancel_token = self.cancel_token.clone();
+        let max_decoding = self.max_decoding_message_size;
+        let max_encoding = self.max_encoding_message_size;
 
         let result: Result<CallResult, GrpcError> = rt.block_on(async move {
             // Build the path
@@ -444,6 +452,12 @@ impl GrpcCall {
 
             // Make the unary call using the raw codec, with cancellation support
             let mut grpc_client = tonic::client::Grpc::new(channel);
+            if let Some(limit) = max_decoding {
+                grpc_client = grpc_client.max_decoding_message_size(limit);
+            }
+            if let Some(limit) = max_encoding {
+                grpc_client = grpc_client.max_encoding_message_size(limit);
+            }
             grpc_client.ready().await.map_err(GrpcError::Transport)?;
 
             let call_future = grpc_client.unary(request, path, RawBytesCodec);
@@ -673,6 +687,8 @@ impl GrpcCall {
         let method = self.method.clone();
         let deadline_usec = self.deadline_usec;
         let cancel_token = self.cancel_token.clone();
+        let max_decoding = self.max_decoding_message_size;
+        let max_encoding = self.max_encoding_message_size;
 
         let path = PathAndQuery::try_from(method.as_str()).map_err(|e| {
             PhpException::from(GrpcError::InvalidArg(format!("invalid method path: {e}")))
@@ -694,6 +710,12 @@ impl GrpcCall {
         // Spawn the stream-driving task
         rt.spawn(async move {
             let mut grpc_client = tonic::client::Grpc::new(channel);
+            if let Some(limit) = max_decoding {
+                grpc_client = grpc_client.max_decoding_message_size(limit);
+            }
+            if let Some(limit) = max_encoding {
+                grpc_client = grpc_client.max_encoding_message_size(limit);
+            }
             if let Err(e) = grpc_client.ready().await {
                 let status = tonic::Status::from_error(Box::new(e));
                 let _ = meta_tx.send(tonic::metadata::MetadataMap::default());
@@ -806,6 +828,8 @@ impl GrpcCall {
         let method = self.method.clone();
         let deadline_usec = self.deadline_usec;
         let cancel_token = self.cancel_token.clone();
+        let max_decoding = self.max_decoding_message_size;
+        let max_encoding = self.max_encoding_message_size;
 
         let path = PathAndQuery::try_from(method.as_str()).map_err(|e| {
             PhpException::from(GrpcError::InvalidArg(format!("invalid method path: {e}")))
@@ -849,6 +873,12 @@ impl GrpcCall {
 
         rt.spawn(async move {
             let mut grpc_client = tonic::client::Grpc::new(channel);
+            if let Some(limit) = max_decoding {
+                grpc_client = grpc_client.max_decoding_message_size(limit);
+            }
+            if let Some(limit) = max_encoding {
+                grpc_client = grpc_client.max_encoding_message_size(limit);
+            }
             if let Err(e) = grpc_client.ready().await {
                 let status = tonic::Status::from_error(Box::new(e));
                 let _ = meta_tx.send(tonic::metadata::MetadataMap::default());

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -18,6 +18,8 @@ struct ChannelInner {
     target: String,
     state: Mutex<i64>,
     call_plugin: Option<Arc<Mutex<Option<Zval>>>>,
+    max_decoding_message_size: Option<usize>,
+    max_encoding_message_size: Option<usize>,
 }
 
 #[php_class]
@@ -104,6 +106,19 @@ impl GrpcChannel {
                 .map_err(|e| PhpException::from(GrpcError::InvalidArg(e.to_string())))?;
         }
 
+        // Extract gRPC message size limits (maps to tonic's max_decoding/encoding_message_size).
+        // The C extension uses grpc.max_receive_message_length / grpc.max_send_message_length;
+        // tonic defaults to 4 MiB decoding / unlimited encoding. A value of -1 means unlimited.
+        let max_decoding_message_size = args
+            .get("grpc.max_receive_message_length")
+            .and_then(|v| v.long())
+            .and_then(|v| if v == -1 { Some(usize::MAX) } else if v > 0 { Some(v as usize) } else { None });
+
+        let max_encoding_message_size = args
+            .get("grpc.max_send_message_length")
+            .and_then(|v| v.long())
+            .and_then(|v| if v == -1 { Some(usize::MAX) } else if v > 0 { Some(v as usize) } else { None });
+
         // Apply TLS config.
         // Always call tls_config() when credentials were provided — tonic requires
         // explicit TLS config even for https:// URLs (it doesn't auto-enable).
@@ -129,6 +144,8 @@ impl GrpcChannel {
                 target,
                 state: Mutex::new(CHANNEL_IDLE),
                 call_plugin,
+                max_decoding_message_size,
+                max_encoding_message_size,
             })),
         })
     }
@@ -197,5 +214,15 @@ impl GrpcChannel {
         self.inner
             .as_ref()
             .and_then(|i| i.call_plugin.as_ref().map(Arc::clone))
+    }
+
+    /// Returns the configured max decoding (receive) message size, if any.
+    pub(crate) fn get_max_decoding_message_size(&self) -> Option<usize> {
+        self.inner.as_ref().and_then(|i| i.max_decoding_message_size)
+    }
+
+    /// Returns the configured max encoding (send) message size, if any.
+    pub(crate) fn get_max_encoding_message_size(&self) -> Option<usize> {
+        self.inner.as_ref().and_then(|i| i.max_encoding_message_size)
     }
 }


### PR DESCRIPTION
## Summary

Maps PHP channel args `grpc.max_receive_message_length` and `grpc.max_send_message_length` to tonic's `max_decoding_message_size` and `max_encoding_message_size`.

Without this, tonic's default 4 MiB decoding limit applies to all calls regardless of the PHP-side configuration, causing `"decoded message length too large"` errors for legitimate large responses.

The C-based ext-grpc honors these channel args natively; this brings grpc-php-rs to parity.

## Changes

- **`src/channel.rs`**: Extract `grpc.max_receive_message_length` and `grpc.max_send_message_length` from the PHP channel args hash table; store in `ChannelInner`; expose via internal getters.
- **`src/call.rs`**: Read limits from `GrpcChannel` in `GrpcCall::__construct`; apply via `grpc_client.max_decoding_message_size()` / `.max_encoding_message_size()` in all three call paths (unary, server streaming, bidi streaming).

## Semantics

| PHP channel arg | tonic method | C ext-grpc default | tonic default | 
|---|---|---|---|
| `grpc.max_receive_message_length` | `max_decoding_message_size` | 4 MiB | 4 MiB |
| `grpc.max_send_message_length` | `max_encoding_message_size` | unlimited | unlimited |

- Value `0` or unset → tonic default (4 MiB decoding, unlimited encoding)
- Value `-1` → unlimited (`usize::MAX`), matching C extension behavior
- Value `> 0` → exact byte limit

## Motivation

We hit this in production: a PHP app sets `grpc.max_receive_message_length => 128 * 1024 * 1024` on the channel, but grpc-php-rs ignored it — tonic kept the 4 MiB default, causing `status=11 "decoded message length too large: found 12952292 bytes, the limit is: 4194304 bytes"` on batched gRPC responses.

Made with [Cursor](https://cursor.com)