### PR TITLE
Surface binary trailing metadata to PHP (-bin keys)

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -133,38 +133,99 @@ fn parse_metadata(ht: &ZendHashTable) -> Vec<(String, String)> {
     metadata
 }
 
-/// Build a metadata array for PHP from a tonic MetadataMap.
-fn metadata_to_php(map: &tonic::metadata::MetadataMap) -> Result<ZBox<ZendHashTable>, GrpcError> {
-    let mut ht = ZendHashTable::new();
+/// A single metadata entry as raw bytes, grouped per key in iteration order.
+///
+/// ASCII values are surfaced as their underlying byte slice (HTTP/2 wire form,
+/// which is also the human-readable form for ASCII keys). Binary (`-bin`) values
+/// are surfaced as the decoded raw bytes, matching `ext-grpc`'s observable
+/// behavior, where PHP user code receives the unmodified payload as a (binary
+/// safe) PHP string.
+type MetadataEntries = Vec<(String, Vec<Vec<u8>>)>;
+
+/// Collect a tonic `MetadataMap` into a flat list of `(key, values)` pairs.
+///
+/// Pure function with no PHP dependencies; unit-tested below. The PHP-binding
+/// layer (`metadata_to_php`) is a thin wrapper that converts the result into a
+/// `ZendHashTable`.
+///
+/// Behaviors:
+///  - Iteration order of the original `MetadataMap` is preserved.
+///  - Repeated keys are collapsed into a `Vec<Vec<u8>>`, matching the historic
+///    "each key maps to an array of values" PHP shape.
+///  - For `KeyAndValueRef::Binary`, the value is decoded via `to_bytes()`
+///    (tonic's API for the decoded payload; `as_encoded_bytes()` would return
+///    the base64 wire form, which we do NOT want). If a malformed binary value
+///    fails to decode, that single entry is skipped rather than failing the
+///    whole call: matches the ASCII branch's prior tolerance of `to_str()`
+///    failures.
+fn collect_metadata(map: &tonic::metadata::MetadataMap) -> MetadataEntries {
+    let mut entries: MetadataEntries = Vec::new();
     for key_and_value in map.iter() {
-        if let tonic::metadata::KeyAndValueRef::Ascii(key, value) = key_and_value {
-            let key_str = key.as_str();
-            if let Ok(val_str) = value.to_str() {
-                // Each metadata key maps to an array of values
-                let existing = ht.get(key_str);
-                if let Some(existing_zval) = existing {
-                    if let Some(arr) = existing_zval.array() {
-                        let mut new_arr = ZendHashTable::new();
-                        for (_k, v) in arr.iter() {
-                            new_arr.push(v.shallow_clone()).map_err(|e| {
-                                GrpcError::InvalidArg(format!("metadata build: {e}"))
-                            })?;
-                        }
-                        new_arr
-                            .push(val_str.to_string())
-                            .map_err(|e| GrpcError::InvalidArg(format!("metadata build: {e}")))?;
-                        ht.insert(key_str, new_arr)
-                            .map_err(|e| GrpcError::InvalidArg(format!("metadata build: {e}")))?;
-                    }
-                } else {
-                    let mut arr = ZendHashTable::new();
-                    arr.push(val_str.to_string())
-                        .map_err(|e| GrpcError::InvalidArg(format!("metadata build: {e}")))?;
-                    ht.insert(key_str, arr)
-                        .map_err(|e| GrpcError::InvalidArg(format!("metadata build: {e}")))?;
+        let (key_str, bytes): (&str, Vec<u8>) = match key_and_value {
+            tonic::metadata::KeyAndValueRef::Ascii(key, value) => {
+                // Preserve the prior behavior of dropping ASCII values that
+                // fail `to_str()` (non-visible-ASCII). In practice tonic only
+                // admits visible-ASCII bytes into `MetadataValue<Ascii>`, so
+                // this branch effectively always succeeds; keeping `to_str()`
+                // here makes the patch purely additive with respect to the
+                // ASCII path.
+                match value.to_str() {
+                    Ok(s) => (key.as_str(), s.as_bytes().to_vec()),
+                    Err(_) => continue,
                 }
             }
+            tonic::metadata::KeyAndValueRef::Binary(key, value) => {
+                // Binary trailers (e.g. `grpc-status-details-bin`) carry
+                // base64-encoded payloads on the wire. `to_bytes()` returns the
+                // decoded bytes, exactly what ext-grpc surfaces to PHP.
+                // `as_encoded_bytes()` would return the base64 wire form, which
+                // we do NOT want.
+                match value.to_bytes() {
+                    Ok(decoded) => (key.as_str(), decoded.to_vec()),
+                    // Drop malformed binary values rather than failing the
+                    // whole map; mirrors the ASCII branch's tolerance pattern.
+                    Err(_) => continue,
+                }
+            }
+        };
+
+        // Group by key, preserving the order in which keys are first seen.
+        if let Some(slot) = entries.iter_mut().find(|(k, _)| k == key_str) {
+            slot.1.push(bytes);
+        } else {
+            entries.push((key_str.to_owned(), vec![bytes]));
         }
+    }
+    entries
+}
+
+/// Convert a slice of raw bytes into a PHP string (binary-safe) wrapped in a
+/// `Zval`. PHP strings are length-prefixed and may contain arbitrary bytes
+/// including null bytes; same shape `ext-grpc` produces for binary trailers.
+fn bytes_to_php_string_zval(bytes: &[u8]) -> Zval {
+    let mut zv = Zval::new();
+    // `ZendStr::new` takes `impl AsRef<[u8]>` and copies the bytes into a
+    // Zend-allocated string; no UTF-8 validation involved.
+    zv.set_zend_string(ext_php_rs::types::ZendStr::new(bytes, false));
+    zv
+}
+
+/// Build a metadata array for PHP from a tonic MetadataMap.
+///
+/// Output shape: `array<string, array<int, string>>`; each metadata key maps
+/// to an ordered list of values. ASCII values are surfaced as their raw bytes
+/// (typically printable ASCII). Binary (`-bin`) values are surfaced as the
+/// decoded raw payload in a PHP binary-safe string, matching `ext-grpc`.
+fn metadata_to_php(map: &tonic::metadata::MetadataMap) -> Result<ZBox<ZendHashTable>, GrpcError> {
+    let mut ht = ZendHashTable::new();
+    for (key, values) in collect_metadata(map) {
+        let mut arr = ZendHashTable::new();
+        for v in &values {
+            arr.push(bytes_to_php_string_zval(v))
+                .map_err(|e| GrpcError::InvalidArg(format!("metadata build: {e}")))?;
+        }
+        ht.insert(key.as_str(), arr)
+            .map_err(|e| GrpcError::InvalidArg(format!("metadata build: {e}")))?;
     }
     Ok(ht)
 }
@@ -1125,5 +1186,109 @@ impl GrpcCall {
         }
 
         Ok(result_obj)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::collect_metadata;
+    use tonic::metadata::{AsciiMetadataValue, BinaryMetadataValue, MetadataKey, MetadataMap};
+
+    /// ASCII metadata is surfaced as raw bytes (the on-wire form), grouped by
+    /// key with insertion order preserved per key.
+    #[test]
+    fn ascii_metadata_is_collected() {
+        let mut map = MetadataMap::new();
+        map.insert("foo", AsciiMetadataValue::from_static("bar"));
+        map.append("foo", AsciiMetadataValue::from_static("baz"));
+        map.insert("other", AsciiMetadataValue::from_static("qux"));
+
+        let collected = collect_metadata(&map);
+
+        let foo = collected.iter().find(|(k, _)| k == "foo");
+        assert!(foo.is_some(), "foo key present");
+        if let Some((_, values)) = foo {
+            assert_eq!(values, &vec![b"bar".to_vec(), b"baz".to_vec()]);
+        }
+
+        let other = collected.iter().find(|(k, _)| k == "other");
+        assert!(other.is_some(), "other key present");
+        if let Some((_, values)) = other {
+            assert_eq!(values, &vec![b"qux".to_vec()]);
+        }
+    }
+
+    /// Binary (`-bin`) metadata is surfaced as the *decoded* raw payload,
+    /// matching ext-grpc. This is the case the previous implementation silently
+    /// dropped, breaking `grpc-status-details-bin` and other rich-status
+    /// propagation.
+    #[test]
+    fn binary_metadata_is_surfaced_as_decoded_bytes() {
+        // Arbitrary binary payload, includes a null byte and a non-UTF-8
+        // sequence to demonstrate that PHP-side surfacing must be byte-safe and
+        // must NOT be base64-encoded.
+        let payload: &[u8] = b"\x00\x01\x02\xff\xfehello\x00world";
+
+        let mut map = MetadataMap::new();
+        let key: Result<MetadataKey<tonic::metadata::Binary>, _> = "x-custom-bin".parse();
+        assert!(key.is_ok(), "binary metadata key must parse");
+        if let Ok(k) = key {
+            map.insert_bin(k, BinaryMetadataValue::from_bytes(payload));
+        }
+
+        let collected = collect_metadata(&map);
+
+        let entry = collected.iter().find(|(k, _)| k == "x-custom-bin");
+        assert!(entry.is_some(), "binary key present in collected output");
+        if let Some((_, values)) = entry {
+            assert_eq!(values.len(), 1, "single value expected");
+            if let Some(first) = values.first() {
+                assert_eq!(
+                    first.as_slice(),
+                    payload,
+                    "binary value must be the decoded raw bytes, not the base64 wire form"
+                );
+            }
+        }
+    }
+
+    /// Mixed map: both ASCII and binary entries must coexist.
+    #[test]
+    fn mixed_ascii_and_binary_are_both_present() {
+        let mut map = MetadataMap::new();
+        map.insert(
+            "content-type",
+            AsciiMetadataValue::from_static("application/grpc"),
+        );
+        let key: Result<MetadataKey<tonic::metadata::Binary>, _> =
+            "grpc-status-details-bin".parse();
+        assert!(key.is_ok());
+        // 4-byte marker that resembles a small protobuf payload.
+        let payload: &[u8] = b"\x08\x05\x12\x00";
+        if let Ok(k) = key {
+            map.insert_bin(k, BinaryMetadataValue::from_bytes(payload));
+        }
+
+        let collected = collect_metadata(&map);
+
+        assert_eq!(collected.len(), 2);
+        assert!(
+            collected
+                .iter()
+                .any(|(k, v)| k == "content-type" && v == &vec![b"application/grpc".to_vec()])
+        );
+        assert!(
+            collected
+                .iter()
+                .any(|(k, v)| k == "grpc-status-details-bin" && v == &vec![payload.to_vec()])
+        );
+    }
+
+    /// Sanity check: an empty `MetadataMap` produces no entries.
+    #[test]
+    fn empty_metadata_produces_empty_entries() {
+        let map = MetadataMap::new();
+        let collected = collect_metadata(&map);
+        assert!(collected.is_empty());
     }
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -139,6 +139,15 @@ COPY tests/test_empty_response.php /app/tests/test_empty_response.php
 CMD ["sh", "-c", "grpc-test-server & sleep 1 && php tests/test_streaming.php && php tests/test_empty_response.php"]
 
 # ---------------------------------------------------------------------------
+# Stage 9c: Binary trailing metadata test runner
+FROM test-base AS test-binary-trailer
+
+COPY --from=test-server-builder /build/target/release/grpc-test-server /usr/local/bin/grpc-test-server
+COPY tests/test_binary_trailer.php /app/tests/test_binary_trailer.php
+
+CMD ["sh", "-c", "grpc-test-server & sleep 1 && php tests/test_binary_trailer.php"]
+
+# ---------------------------------------------------------------------------
 # Stage 10: Integration test base — Temporal SDK
 FROM test-base AS test-integration-base
 

--- a/tests/server/src/main.rs
+++ b/tests/server/src/main.rs
@@ -18,7 +18,15 @@ impl TestService for TestServiceImpl {
     type BidiEchoStream = ReceiverStream<Result<Payload, Status>>;
 
     async fn echo(&self, request: Request<Payload>) -> Result<Response<Payload>, Status> {
-        Ok(Response::new(request.into_inner()))
+        let mut response = Response::new(request.into_inner());
+        // Attach a binary trailer so PHP clients can verify their extension
+        // surfaces `-bin` metadata. Payload contains a NUL and non-UTF-8 byte
+        // to make sure raw bytes survive intact (no string conversion).
+        response.metadata_mut().insert_bin(
+            "x-test-binary-bin",
+            tonic::metadata::MetadataValue::from_bytes(b"hello\x00\xfftrailer"),
+        );
+        Ok(response)
     }
 
     async fn empty_response(&self, _request: Request<Payload>) -> Result<Response<Empty>, Status> {
@@ -39,7 +47,20 @@ impl TestService for TestServiceImpl {
         &self,
         _request: Request<Payload>,
     ) -> Result<Response<Payload>, Status> {
-        Err(Status::internal("test error"))
+        // Attach a binary trailer via Status metadata. This is the path real
+        // services use for rich-status / google.rpc.Status propagation in
+        // `grpc-status-details-bin`. Surfaces to PHP through the trailing
+        // metadata in OP_RECV_STATUS_ON_CLIENT.
+        let mut md = tonic::metadata::MetadataMap::new();
+        md.insert_bin(
+            "x-test-binary-bin",
+            tonic::metadata::MetadataValue::from_bytes(b"hello\x00\xfftrailer"),
+        );
+        Err(Status::with_metadata(
+            tonic::Code::Internal,
+            "test error",
+            md,
+        ))
     }
 
     async fn stream_echo(

--- a/tests/test_binary_trailer.php
+++ b/tests/test_binary_trailer.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Binary trailing metadata test. Exercises the `-bin` trailer code path
+ * that this PR (binary-metadata surfacing) restores.
+ *
+ * The Rust test server attaches a binary trailer `x-test-binary-bin` to the
+ * Echo response. This test asserts the bytes are surfaced to PHP intact
+ * (no UTF-8 conversion, NUL and non-UTF-8 bytes preserved).
+ *
+ * Run:
+ *   # Terminal 1: cargo run --manifest-path tests/server/Cargo.toml
+ *   # Terminal 2: php tests/test_binary_trailer.php
+ */
+declare(strict_types=1);
+
+echo "=== Binary Trailing Metadata Test ===\n\n";
+
+function encode_payload(string $data): string {
+    if ($data === '') return '';
+    return "\x0a" . encode_varint(strlen($data)) . $data;
+}
+
+function encode_varint(int $value): string {
+    $buf = '';
+    while ($value > 0x7f) {
+        $buf .= chr(($value & 0x7f) | 0x80);
+        $value >>= 7;
+    }
+    $buf .= chr($value & 0x7f);
+    return $buf;
+}
+
+$tests = 0;
+$passed = 0;
+function check(string $name, bool $result, string $detail = ''): void {
+    global $tests, $passed;
+    $tests++;
+    if ($result) { $passed++; echo "  ✓ {$name}\n"; }
+    else { echo "  ✗ {$name}" . ($detail ? ": {$detail}" : '') . "\n"; }
+}
+
+$expected = "hello\x00\xfftrailer";  // matches tests/server/src/main.rs
+$target = 'localhost:50051';
+$channel = new Grpc\Channel($target, []);
+
+// -----------------------------------------------------------------------------
+// Case 1: Echo response, binary metadata via Response::metadata_mut().
+// In tonic 0.12, metadata_mut() on a successful unary response populates the
+// initial-metadata HEADERS frame. Verifies our metadata_to_php fix on the
+// initial-metadata receive path.
+// -----------------------------------------------------------------------------
+echo "--- Case 1: success response, binary header ---\n";
+
+$call = new Grpc\Call($channel, '/grpc.testing.TestService/Echo', Grpc\Timeval::infFuture());
+$r1 = $call->startBatch([
+    Grpc\OP_SEND_INITIAL_METADATA => [],
+    Grpc\OP_SEND_MESSAGE => encode_payload('hi'),
+    Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
+    Grpc\OP_RECV_INITIAL_METADATA => true,
+    Grpc\OP_RECV_MESSAGE => true,
+    Grpc\OP_RECV_STATUS_ON_CLIENT => true,
+]);
+
+check('echo: status OK', ($r1->status->code ?? -1) === Grpc\STATUS_OK);
+$initial = $r1->metadata ?? [];
+check('echo: x-test-binary-bin in initial metadata',
+    is_array($initial) && array_key_exists('x-test-binary-bin', $initial),
+    'keys=' . (is_array($initial) ? implode(',', array_keys($initial)) : 'null'));
+$got = $initial['x-test-binary-bin'][0] ?? '';
+check('echo: byte-exact match (NUL + non-UTF-8 preserved)', $got === $expected,
+    'expected=' . bin2hex($expected) . ' got=' . bin2hex($got));
+
+// -----------------------------------------------------------------------------
+// Case 2: Error response, binary metadata attached via Status::with_metadata.
+// This is the path real services use for rich-status (google.rpc.Status over
+// grpc-status-details-bin), surfaces on the trailing-metadata receive path.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 2: error response, binary trailer ---\n";
+
+$call = new Grpc\Call($channel, '/grpc.testing.TestService/ErrorResponse', Grpc\Timeval::infFuture());
+$r2 = $call->startBatch([
+    Grpc\OP_SEND_INITIAL_METADATA => [],
+    Grpc\OP_SEND_MESSAGE => encode_payload('hi'),
+    Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
+    Grpc\OP_RECV_INITIAL_METADATA => true,
+    Grpc\OP_RECV_MESSAGE => true,
+    Grpc\OP_RECV_STATUS_ON_CLIENT => true,
+]);
+
+check('error: status INTERNAL', ($r2->status->code ?? -1) === Grpc\STATUS_INTERNAL,
+    'code=' . var_export($r2->status->code ?? null, true));
+$trailers = $r2->status->metadata ?? [];
+check('error: x-test-binary-bin in trailing metadata',
+    is_array($trailers) && array_key_exists('x-test-binary-bin', $trailers),
+    'keys=' . (is_array($trailers) ? implode(',', array_keys($trailers)) : 'null'));
+$got = $trailers['x-test-binary-bin'][0] ?? '';
+check('error: byte-exact match (NUL + non-UTF-8 preserved)', $got === $expected,
+    'expected=' . bin2hex($expected) . ' got=' . bin2hex($got));
+
+echo "\n=== {$passed}/{$tests} tests passed ===\n";
+exit($passed === $tests ? 0 : 1);


### PR DESCRIPTION
## Problem

`metadata_to_php()` in `src/call.rs` pattern-matches only on `tonic::metadata::KeyAndValueRef::Ascii`. Every `KeyAndValueRef::Binary` entry falls through and is silently dropped. PHP user code never sees binary metadata (initial or trailing). This single helper is on all three metadata-surfacing paths in the crate, so the bug affects every direction.

## Real-world impact

`-bin` trailers are spec'd by gRPC (any header ending in `-bin` is binary-valued, base64-transported on the wire). The most common consumer is rich-status: `google.rpc.Status` ships over `grpc-status-details-bin`, the standard mechanism for typed errors from Google Cloud APIs (https://cloud.google.com/apis/design/errors). Dropping all binary trailers means PHP clients of this crate cannot decode `google.rpc.Status` details and cannot consume any custom binary trailer. Blocks drop-in replacement of `ext-grpc` for any rich-status service.

## Fix

Add a `KeyAndValueRef::Binary` arm. Decode via `MetadataValue<Binary>::to_bytes()` (decoded payload; `as_encoded_bytes()` would return the base64 wire form, which is wrong). Surface the bytes as a binary-safe PHP string (PHP strings are length-prefixed and tolerate null / non-UTF-8 bytes), matching `ext-grpc`. PHP user code is responsible for further unpacking (e.g. `Google\Rpc\Status::mergeFromString($value)`).

Refactored `metadata_to_php` into a pure-Rust inner `collect_metadata(&MetadataMap) -> Vec<(String, Vec<Vec<u8>>)>` (unit-testable without a PHP runtime) plus a thin PHP-binding wrapper that assembles the `ZendHashTable` via `ZendStr::new(&bytes, false)` (accepts `impl AsRef<[u8]>`, no UTF-8 validation). Malformed binary values are skipped, mirroring the ASCII branch's existing tolerance of `to_str()` failures.

## Tests

Two layers:

1. **Unit tests** (`#[cfg(test)] mod tests` in `src/call.rs`, matching the inline-tests convention in `error.rs` / `runtime.rs` / `codec.rs`): ASCII grouping, binary round-trip with a payload containing `\x00` and non-UTF-8 bytes (regression test for the silent drop), mixed ASCII + binary, and empty-map sanity.

2. **End-to-end integration test** (`tests/test_binary_trailer.php` + new `test-binary-trailer` Dockerfile stage). The test server's `Echo` attaches a binary value via `Response::metadata_mut().insert_bin(...)` (initial metadata for unary). `ErrorResponse` attaches one via `Status::with_metadata(...).insert_bin(...)` (trailing metadata, the actual rich-status code path). PHP client asserts byte-exact round-trip including `\x00` and `\xff` on both paths.

Verified locally: `./test.sh smoke` 51/51 pass, `./test.sh compat` 6/6 pass, the new binary-trailer test 6/6 pass.

## Compatibility

Strictly additive. ASCII paths unchanged (still `to_str()`-gated). The output shape `array<string, array<int, string>>` is preserved. PHP code that didn't use binary trailers continues to behave identically; PHP code that previously got nothing for binary trailers will now get populated entries matching `ext-grpc`.

## Reference

`ext-grpc` surfaces binary trailers as PHP strings of raw bytes (see `PHP_METHOD(Call, startBatch)` for `op->data.recv_status_on_client.trailing_metadata` in https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/call.c).
