### PR TITLE
fix: restore grpc-status-details-bin trailer lost to tonic's reserved-header stripping

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -265,6 +265,24 @@ fn metadata_to_php(map: &tonic::metadata::MetadataMap) -> Result<ZBox<ZendHashTa
     Ok(ht)
 }
 
+/// Reconstruct the metadata that ext-grpc exposes for an error status.
+///
+/// tonic treats `grpc-status-details-bin` as a transport header: when it
+/// creates a `Status` from response trailers, it decodes that header into
+/// `Status::details()` and removes it from `Status::metadata()`.  ext-grpc
+/// instead exposes the decoded bytes as ordinary trailing metadata, so put it
+/// back before converting the metadata to PHP.
+fn status_metadata_for_php(status: &tonic::Status) -> tonic::metadata::MetadataMap {
+    let mut metadata = status.metadata().clone();
+    if !status.details().is_empty() {
+        metadata.insert_bin(
+            "grpc-status-details-bin",
+            tonic::metadata::MetadataValue::from_bytes(status.details()),
+        );
+    }
+    metadata
+}
+
 /// Async result from a gRPC call.
 type CallResult = (
     Option<tonic::metadata::MetadataMap>,
@@ -571,7 +589,7 @@ impl GrpcCall {
                         Err(status) => {
                             let code = status.code() as i32;
                             let msg = status.message().to_string();
-                            let md = status.metadata().clone();
+                            let md = status_metadata_for_php(&status);
                             Ok((None, None, Some(md), code, msg))
                         }
                     }
@@ -856,7 +874,7 @@ impl GrpcCall {
                                     Err(status) => {
                                         let code = status.code() as i32;
                                         let message = status.message().to_string();
-                                        let md = status.metadata().clone();
+                                        let md = status_metadata_for_php(&status);
                                         let _ = msg_tx.send(Ok(None)).await;
                                         let _ = trailers_tx.send(StreamTrailers {
                                             code,
@@ -884,7 +902,7 @@ impl GrpcCall {
                     let _ = meta_tx.send(tonic::metadata::MetadataMap::default());
                     let code = status.code() as i32;
                     let message = status.message().to_string();
-                    let md = status.metadata().clone();
+                    let md = status_metadata_for_php(&status);
                     let _ = msg_tx.send(Ok(None)).await;
                     let _ = trailers_tx.send(StreamTrailers {
                         code,
@@ -1016,7 +1034,7 @@ impl GrpcCall {
                                     Err(status) => {
                                         let code = status.code() as i32;
                                         let message = status.message().to_string();
-                                        let md = status.metadata().clone();
+                                        let md = status_metadata_for_php(&status);
                                         let _ = msg_tx.send(Ok(None)).await;
                                         let _ = trailers_tx.send(StreamTrailers {
                                             code,
@@ -1043,7 +1061,7 @@ impl GrpcCall {
                     let _ = meta_tx.send(tonic::metadata::MetadataMap::default());
                     let code = status.code() as i32;
                     let message = status.message().to_string();
-                    let md = status.metadata().clone();
+                    let md = status_metadata_for_php(&status);
                     let _ = msg_tx.send(Ok(None)).await;
                     let _ = trailers_tx.send(StreamTrailers {
                         code,
@@ -1171,7 +1189,7 @@ impl GrpcCall {
                         state.cached_trailers = Some(StreamTrailers {
                             code: status.code() as i32,
                             message: status.message().to_string(),
-                            metadata: status.metadata().clone(),
+                            metadata: status_metadata_for_php(&status),
                         });
                         let mut null_zval = Zval::new();
                         null_zval.set_null();
@@ -1234,7 +1252,7 @@ impl GrpcCall {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_metadata;
+    use super::{collect_metadata, status_metadata_for_php};
     use tonic::metadata::{AsciiMetadataValue, BinaryMetadataValue, MetadataKey, MetadataMap};
 
     /// ASCII metadata is surfaced as raw bytes (the on-wire form), grouped by
@@ -1324,6 +1342,52 @@ mod tests {
             collected
                 .iter()
                 .any(|(k, v)| k == "grpc-status-details-bin" && v == &vec![payload.to_vec()])
+        );
+    }
+
+    /// `Status::from_header_map` removes this reserved header from metadata
+    /// and stores its decoded payload in `Status::details()`. Re-inject it for
+    /// PHP so the observable trailing metadata matches ext-grpc.
+    #[test]
+    fn status_details_bin_is_reinjected_after_tonic_parses_headers() {
+        let payload: &[u8] = b"\x08\x0d\x12\x0brich status";
+        // This is the exact trailer representation emitted by gRPC on the
+        // wire. `CA0SC3JpY2ggc3RhdHVz` is the base64 encoding of `payload`.
+        let mut header_map = http::HeaderMap::new();
+        header_map.insert("grpc-status", http::HeaderValue::from_static("13"));
+        header_map.insert(
+            "grpc-message",
+            http::HeaderValue::from_static("test%20error"),
+        );
+        header_map.insert(
+            "grpc-status-details-bin",
+            http::HeaderValue::from_static("CA0SC3JpY2ggc3RhdHVz"),
+        );
+
+        assert!(
+            header_map.contains_key("grpc-status-details-bin"),
+            "the wire header uses tonic's reserved key"
+        );
+        let status = tonic::Status::from_header_map(&header_map);
+        assert!(status.is_some(), "tonic must parse a status header map");
+        let Some(status) = status else {
+            return;
+        };
+        assert_eq!(status.details(), payload);
+        assert!(
+            status
+                .metadata()
+                .get_bin("grpc-status-details-bin")
+                .is_none(),
+            "tonic removes its reserved header from Status metadata"
+        );
+
+        let collected = collect_metadata(&status_metadata_for_php(&status));
+        assert!(
+            collected.iter().any(|(key, values)| {
+                key == "grpc-status-details-bin" && values == &vec![payload.to_vec()]
+            }),
+            "PHP trailing metadata receives the decoded rich-status payload"
         );
     }
 

--- a/tests/server/src/main.rs
+++ b/tests/server/src/main.rs
@@ -47,19 +47,14 @@ impl TestService for TestServiceImpl {
         &self,
         _request: Request<Payload>,
     ) -> Result<Response<Payload>, Status> {
-        // Attach a binary trailer via Status metadata. This is the path real
-        // services use for rich-status / google.rpc.Status propagation in
-        // `grpc-status-details-bin`. Surfaces to PHP through the trailing
-        // metadata in OP_RECV_STATUS_ON_CLIENT.
-        let mut md = tonic::metadata::MetadataMap::new();
-        md.insert_bin(
-            "x-test-binary-bin",
-            tonic::metadata::MetadataValue::from_bytes(b"hello\x00\xfftrailer"),
-        );
-        Err(Status::with_metadata(
+        // `with_details` serializes this as tonic's reserved
+        // `grpc-status-details-bin` header. The client then reconstructs the
+        // Status using `Status::from_header_map`, which moves this payload out
+        // of `status.metadata()` and into `status.details()`.
+        Err(Status::with_details(
             tonic::Code::Internal,
             "test error",
-            md,
+            b"hello\x00\xfftrailer".to_vec().into(),
         ))
     }
 
@@ -78,6 +73,19 @@ impl TestService for TestServiceImpl {
             .and_then(|n| n.parse::<usize>().ok());
 
         tokio::spawn(async move {
+            // End a stream after response headers with a rich status. This
+            // exercises the client's `Streaming::message()` error path.
+            if payload.body.as_slice() == b"stream-status-error" {
+                let _ = tx
+                    .send(Err(Status::with_details(
+                        tonic::Code::Internal,
+                        "stream test error",
+                        b"hello\x00\xfftrailer".to_vec().into(),
+                    )))
+                    .await;
+                return;
+            }
+
             match repeat {
                 Some(n) => {
                     let msg = Payload { body: b"x".to_vec() };

--- a/tests/test_binary_trailer.php
+++ b/tests/test_binary_trailer.php
@@ -71,9 +71,10 @@ check('echo: byte-exact match (NUL + non-UTF-8 preserved)', $got === $expected,
     'expected=' . bin2hex($expected) . ' got=' . bin2hex($got));
 
 // -----------------------------------------------------------------------------
-// Case 2: Error response, binary metadata attached via Status::with_metadata.
-// This is the path real services use for rich-status (google.rpc.Status over
-// grpc-status-details-bin), surfaces on the trailing-metadata receive path.
+// Case 2: Error response, rich-status bytes attached via Status::with_details.
+// tonic parses the literal reserved `grpc-status-details-bin` header into
+// Status::details(), so this verifies grpc-php-rs restores it to trailing
+// metadata on the PHP receive path.
 // -----------------------------------------------------------------------------
 echo "\n--- Case 2: error response, binary trailer ---\n";
 
@@ -90,11 +91,44 @@ $r2 = $call->startBatch([
 check('error: status INTERNAL', ($r2->status->code ?? -1) === Grpc\STATUS_INTERNAL,
     'code=' . var_export($r2->status->code ?? null, true));
 $trailers = $r2->status->metadata ?? [];
-check('error: x-test-binary-bin in trailing metadata',
-    is_array($trailers) && array_key_exists('x-test-binary-bin', $trailers),
+check('error: grpc-status-details-bin in trailing metadata',
+    is_array($trailers) && array_key_exists('grpc-status-details-bin', $trailers),
     'keys=' . (is_array($trailers) ? implode(',', array_keys($trailers)) : 'null'));
-$got = $trailers['x-test-binary-bin'][0] ?? '';
+$got = $trailers['grpc-status-details-bin'][0] ?? '';
 check('error: byte-exact match (NUL + non-UTF-8 preserved)', $got === $expected,
+    'expected=' . bin2hex($expected) . ' got=' . bin2hex($got));
+
+// -----------------------------------------------------------------------------
+// Case 3: Server-streaming error after response headers. This takes tonic's
+// `Streaming::message()` error path and ensures rich status is restored to the
+// metadata that RECV_STATUS_ON_CLIENT receives.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 3: streaming error, rich-status trailer ---\n";
+
+$call = new Grpc\Call($channel, '/grpc.testing.TestService/StreamEcho', Grpc\Timeval::infFuture());
+$call->startBatch([
+    Grpc\OP_SEND_INITIAL_METADATA => [],
+    Grpc\OP_SEND_MESSAGE => encode_payload('stream-status-error'),
+    Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
+]);
+$call->startBatch([
+    Grpc\OP_RECV_INITIAL_METADATA => true,
+]);
+$streamMessage = $call->startBatch([
+    Grpc\OP_RECV_MESSAGE => true,
+]);
+check('streaming error: message is null', $streamMessage->message === null);
+$streamStatus = $call->startBatch([
+    Grpc\OP_RECV_STATUS_ON_CLIENT => true,
+]);
+check('streaming error: status INTERNAL', ($streamStatus->status->code ?? -1) === Grpc\STATUS_INTERNAL,
+    'code=' . var_export($streamStatus->status->code ?? null, true));
+$streamTrailers = $streamStatus->status->metadata ?? [];
+check('streaming error: grpc-status-details-bin in trailing metadata',
+    is_array($streamTrailers) && array_key_exists('grpc-status-details-bin', $streamTrailers),
+    'keys=' . (is_array($streamTrailers) ? implode(',', array_keys($streamTrailers)) : 'null'));
+$got = $streamTrailers['grpc-status-details-bin'][0] ?? '';
+check('streaming error: byte-exact match (NUL + non-UTF-8 preserved)', $got === $expected,
     'expected=' . bin2hex($expected) . ' got=' . bin2hex($got));
 
 echo "\n=== {$passed}/{$tests} tests passed ===\n";


### PR DESCRIPTION
## Problem

`grpc-status-details-bin` never reaches PHP on an error response.

`tonic::Status::from_header_map()` treats `grpc-status`, `grpc-message`, and `grpc-status-details-bin` as reserved protocol headers: it removes all three from the trailer map before building `Status`, and stores the decoded `grpc-status-details-bin` payload separately in `Status::details()` rather than leaving it in `Status::metadata()`.

Every call path in `src/call.rs` that surfaces trailing metadata to PHP reads only `status.metadata()`, so this specific reserved key is unconditionally absent for unary, server-streaming, and client-streaming/bidi error responses — regardless of the fix in #11, which restored generic `-bin` trailer support but did not account for tonic stripping this literal key before that code ever runs.

## Real-world impact

Any service that uses the standard rich-status pattern loses that payload silently on the PHP side whenever a call fails. Client code that reads `grpc-status-details-bin` from the trailing metadata (the documented, `ext-grpc`-compatible way to unpack `google.rpc.Status` details) always gets an empty result and falls back to generic error handling — indistinguishable from a service that legitimately sent no details. This breaks drop-in compatibility with `ext-grpc`, which surfaces this key as ordinary trailing metadata with no special-casing.

This also explains why the integration test added in #11 didn't catch it: it exercises a custom key (`x-test-binary-bin`) rather than the literal reserved name, so it never goes through `Status::from_header_map()`'s stripping behavior.

## Fix

Add `status_metadata_for_php()`, which clones `status.metadata()` and, when `status.details()` is non-empty, re-inserts the decoded bytes under the literal `grpc-status-details-bin` key via `insert_bin`. This restores parity with `ext-grpc`, which never special-cases this trailer in the first place.

Applied at every call site that previously built outgoing metadata via `status.metadata().clone()`: the unary error path, both server-streaming error paths, both client-streaming/bidi error paths, and the cached-trailers path used by `Streaming::message()`.

## Tests

- New unit test (`status_details_bin_is_reinjected_after_tonic_parses_headers`) builds a real wire-format `http::HeaderMap` with literal `grpc-status`, `grpc-message`, and `grpc-status-details-bin` headers and runs it through the actual `tonic::Status::from_header_map()` parser — the same path production traffic takes. Confirms tonic strips the key as expected *and* that `status_metadata_for_php()` restores it.
- Updated `tests/test_binary_trailer.php` Case 2 (and the test server) to use `Status::with_details()` — tonic's real rich-status API — instead of a custom `-bin` key attached via `Status::with_metadata()`, and check for the literal `grpc-status-details-bin` key on the PHP side.
- Added Case 3: a server-streaming error, verifying the fix also applies to the `Streaming::message()` error path, not just unary.

Verified locally:
- `cargo test` — 10/10 pass
- `cargo clippy -- -D warnings` — clean
- `./test.sh smoke` — 53/53 pass
- `docker build --target test-binary-trailer` + `docker run` — 10/10 pass,
  including the new streaming case

## Compatibility

Purely additive: only takes effect when `status.details()` is non-empty (i.e. the peer actually sent rich-status details). No behavior change for callers that don't use this feature.
