### PR TITLE
Send unary requests during the start batch (fixes #18)

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -423,8 +423,26 @@ impl GrpcCall {
                 if let Some(msg) = batch.send_message {
                     self.send_stream_message(msg)?;
                 }
+            } else if batch.send_close {
+                // The request is complete (message + client half-close), so it
+                // goes on the wire now. UnaryCall::start() and
+                // ServerStreamingCall::start() both land here; holding the
+                // request back until the recv batch would serialise every call
+                // a caller starts concurrently.
+                let mut send_metadata = std::mem::take(&mut self.pending_metadata);
+                send_metadata.extend(batch.send_metadata);
+                let send_message = batch.send_message.or_else(|| self.pending_message.take());
+
+                let mut plugin_metadata = Vec::new();
+                if let Some(ref plugin) = self.call_plugin {
+                    plugin_metadata =
+                        invoke_call_plugin(plugin, &self.method).map_err(PhpException::from)?;
+                }
+
+                self.start_server_stream(send_metadata, plugin_metadata, send_message)?;
             } else {
-                // Buffer for unary or server streaming (existing behavior)
+                // Buffer until the request is complete (client/bidi streaming
+                // opens with a metadata-only batch).
                 self.pending_metadata = batch.send_metadata;
                 self.pending_message = batch.send_message;
 
@@ -933,15 +951,14 @@ impl GrpcCall {
             }
         });
 
-        // Synchronously wait for initial metadata (the stream task sends it
-        // as soon as the server responds with headers).
-        let initial_metadata = rt.block_on(meta_rx).ok();
-
+        // Headers are resolved on demand in build_stream_result. Awaiting them
+        // here would block the PHP thread for a full round trip before start()
+        // returns, which re-serialises calls the caller started concurrently.
         self.stream_state = Some(ActiveStream {
             msg_tx: None,
             msg_rx,
-            initial_metadata,
-            meta_rx: None,
+            initial_metadata: None,
+            meta_rx: Some(meta_rx),
             cached_trailers: None,
             trailers_rx: Some(trailers_rx),
         });
@@ -1135,16 +1152,78 @@ impl GrpcCall {
             .as_mut()
             .ok_or_else(|| PhpException::default("no active stream".into()))?;
 
+        // Resolve every receiver this batch needs in a single runtime entry.
+        // Each block_on costs a park/wake round trip, and a unary recv batch
+        // asks for headers, message and trailers together.
+        let mut msg: Option<Result<Option<Bytes>, tonic::Status>> = None;
+        let mut msg_resolved = false;
+        if batch.recv_message && state.cached_trailers.is_none() {
+            // Fast path: a buffered message needs no runtime entry at all.
+            match state.msg_rx.try_recv() {
+                Ok(m) => {
+                    msg = Some(m);
+                    msg_resolved = true;
+                }
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {}
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    msg_resolved = true;
+                }
+            }
+        }
+
+        let await_meta = batch.recv_initial_metadata && state.initial_metadata.is_none();
+        let await_msg = batch.recv_message && state.cached_trailers.is_none() && !msg_resolved;
+        let await_trailers = batch.recv_status && state.cached_trailers.is_none();
+
+        let mut trailers: Option<StreamTrailers> = None;
+        if await_meta || await_msg || await_trailers {
+            let meta_rx = if await_meta { state.meta_rx.take() } else { None };
+            let trailers_rx = if await_trailers {
+                state.trailers_rx.take()
+            } else {
+                None
+            };
+            let msg_rx = &mut state.msg_rx;
+
+            let (meta_out, msg_out, trailers_out, trailers_rx_unused) =
+                rt.block_on(async move {
+                    let meta = match meta_rx {
+                        Some(rx) => rx.await.ok(),
+                        None => None,
+                    };
+                    let m = if await_msg { msg_rx.recv().await } else { None };
+                    // A mid-stream error carries the final status itself, and
+                    // the task that produced it may never send trailers.
+                    let (t, unused) = match trailers_rx {
+                        Some(rx) if !matches!(m, Some(Err(_))) => (
+                            Some(rx.await.unwrap_or(StreamTrailers {
+                                code: 2, // UNKNOWN
+                                message: "stream task terminated unexpectedly".into(),
+                                metadata: tonic::metadata::MetadataMap::default(),
+                            })),
+                            None,
+                        ),
+                        other => (None, other),
+                    };
+                    (meta, m, t, unused)
+                });
+
+            if await_meta {
+                state.initial_metadata = meta_out;
+            }
+            if await_msg {
+                msg = msg_out;
+            }
+            trailers = trailers_out;
+            if let Some(rx) = trailers_rx_unused {
+                state.trailers_rx = Some(rx);
+            }
+        }
+
         let mut result_obj = ZendObject::new_stdclass();
 
         // RECV_INITIAL_METADATA — resolve deferred or take stored metadata
         if batch.recv_initial_metadata {
-            // If metadata hasn't arrived yet (bidi/client streaming), await it now
-            if state.initial_metadata.is_none()
-                && let Some(rx) = state.meta_rx.take()
-            {
-                state.initial_metadata = rt.block_on(rx).ok();
-            }
             if let Some(ref md) = state.initial_metadata.take() {
                 result_obj
                     .set_property("metadata", metadata_to_php(md).map_err(PhpException::from)?)
@@ -1172,16 +1251,6 @@ impl GrpcCall {
                     },
                 )?;
             } else {
-                // Fast path: a buffered message skips block_on (and its
-                // runtime-context entry + park) entirely.
-                let msg: Option<Result<Option<Bytes>, tonic::Status>> =
-                    match state.msg_rx.try_recv() {
-                        Ok(m) => Some(m),
-                        Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
-                            rt.block_on(async { state.msg_rx.recv().await })
-                        }
-                        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => None,
-                    };
                 match msg {
                     Some(Ok(Some(bytes))) => {
                         let bin: ext_php_rs::binary::Binary<u8> = Vec::from(bytes).into();
@@ -1223,7 +1292,9 @@ impl GrpcCall {
 
         // RECV_STATUS_ON_CLIENT — return final status
         if batch.recv_status {
-            let trailers = if let Some(cached) = state.cached_trailers.take() {
+            let trailers = if let Some(resolved) = trailers.take() {
+                resolved
+            } else if let Some(cached) = state.cached_trailers.take() {
                 cached
             } else if let Some(rx) = state.trailers_rx.take() {
                 rt.block_on(rx).unwrap_or(StreamTrailers {

--- a/src/call.rs
+++ b/src/call.rs
@@ -97,6 +97,34 @@ fn array_key_to_long(key: &ArrayKey<'_>) -> Result<i64, GrpcError> {
     }
 }
 
+/// Wall-clock microseconds since the Unix epoch.
+fn now_usec() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0i64, |d| d.as_micros() as i64)
+}
+
+/// Map a tonic status onto the (code, message) pair the C extension reports.
+///
+/// tonic surfaces an expired client deadline as CANCELLED "Timeout expired"
+/// (it maps `TimeoutExpired` that way, dropping the source so the cause cannot
+/// be recovered from the status itself), where ext-grpc reports
+/// DEADLINE_EXCEEDED "Deadline Exceeded". Callers branch on that code —
+/// google/gax retries DEADLINE_EXCEEDED and gives up on CANCELLED — so a
+/// CANCELLED arriving after the deadline we set is reported as the deadline.
+/// Cancellation through `Call::cancel()` never reaches here; it is answered
+/// from the cancellation token instead.
+fn status_to_php(status: &tonic::Status, deadline_usec: i64) -> (i32, String) {
+    let code = status.code() as i32;
+    let deadline_set = deadline_usec > 0 && deadline_usec < i64::MAX;
+
+    if code == tonic::Code::Cancelled as i32 && deadline_set && now_usec() >= deadline_usec {
+        return (4, "Deadline Exceeded".to_string());
+    }
+
+    (code, status.message().to_string())
+}
+
 /// Invoke a CallCredentials plugin callable on the PHP thread.
 ///
 /// Returns a vec of (key, value) metadata pairs.
@@ -555,10 +583,7 @@ impl GrpcCall {
 
             // Apply deadline/timeout
             if deadline_usec < i64::MAX && deadline_usec > 0 {
-                let now_usec = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_or(0i64, |d| d.as_micros() as i64);
-                let timeout_usec = deadline_usec.saturating_sub(now_usec);
+                let timeout_usec = deadline_usec.saturating_sub(now_usec());
                 if timeout_usec > 0 {
                     request.set_timeout(std::time::Duration::from_micros(timeout_usec as u64));
                 }
@@ -587,8 +612,7 @@ impl GrpcCall {
                             Ok((Some(resp_metadata), Some(body), None, 0i32, String::new()))
                         }
                         Err(status) => {
-                            let code = status.code() as i32;
-                            let msg = status.message().to_string();
+                            let (code, msg) = status_to_php(&status, deadline_usec);
                             let md = status_metadata_for_php(&status);
                             Ok((None, None, Some(md), code, msg))
                         }
@@ -775,10 +799,7 @@ impl GrpcCall {
         }
 
         if deadline_usec < i64::MAX && deadline_usec > 0 {
-            let now_usec = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_or(0i64, |d| d.as_micros() as i64);
-            let timeout_usec = deadline_usec.saturating_sub(now_usec);
+            let timeout_usec = deadline_usec.saturating_sub(now_usec());
             if timeout_usec > 0 {
                 request.set_timeout(std::time::Duration::from_micros(timeout_usec as u64));
             }
@@ -872,8 +893,8 @@ impl GrpcCall {
                                         return;
                                     }
                                     Err(status) => {
-                                        let code = status.code() as i32;
-                                        let message = status.message().to_string();
+                                        let (code, message) =
+                                            status_to_php(&status, deadline_usec);
                                         let md = status_metadata_for_php(&status);
                                         let _ = msg_tx.send(Ok(None)).await;
                                         let _ = trailers_tx.send(StreamTrailers {
@@ -900,8 +921,7 @@ impl GrpcCall {
                 Err(status) => {
                     // Connection-level or early error — no stream opened
                     let _ = meta_tx.send(tonic::metadata::MetadataMap::default());
-                    let code = status.code() as i32;
-                    let message = status.message().to_string();
+                    let (code, message) = status_to_php(&status, deadline_usec);
                     let md = status_metadata_for_php(&status);
                     let _ = msg_tx.send(Ok(None)).await;
                     let _ = trailers_tx.send(StreamTrailers {
@@ -970,10 +990,7 @@ impl GrpcCall {
             }
         }
         if deadline_usec < i64::MAX && deadline_usec > 0 {
-            let now_usec = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_or(0i64, |d| d.as_micros() as i64);
-            let timeout_usec = deadline_usec.saturating_sub(now_usec);
+            let timeout_usec = deadline_usec.saturating_sub(now_usec());
             if timeout_usec > 0 {
                 request.set_timeout(std::time::Duration::from_micros(timeout_usec as u64));
             }
@@ -1032,8 +1049,8 @@ impl GrpcCall {
                                         return;
                                     }
                                     Err(status) => {
-                                        let code = status.code() as i32;
-                                        let message = status.message().to_string();
+                                        let (code, message) =
+                                            status_to_php(&status, deadline_usec);
                                         let md = status_metadata_for_php(&status);
                                         let _ = msg_tx.send(Ok(None)).await;
                                         let _ = trailers_tx.send(StreamTrailers {
@@ -1059,8 +1076,7 @@ impl GrpcCall {
                 }
                 Err(status) => {
                     let _ = meta_tx.send(tonic::metadata::MetadataMap::default());
-                    let code = status.code() as i32;
-                    let message = status.message().to_string();
+                    let (code, message) = status_to_php(&status, deadline_usec);
                     let md = status_metadata_for_php(&status);
                     let _ = msg_tx.send(Ok(None)).await;
                     let _ = trailers_tx.send(StreamTrailers {
@@ -1113,6 +1129,7 @@ impl GrpcCall {
     /// Build a PHP result object from the active stream state.
     fn build_stream_result(&mut self, batch: &BatchOps) -> PhpResult<ZBox<ZendObject>> {
         let rt = get_runtime().map_err(PhpException::from)?;
+        let deadline_usec = self.deadline_usec;
         let state = self
             .stream_state
             .as_mut()
@@ -1186,9 +1203,10 @@ impl GrpcCall {
                     }
                     Some(Err(status)) => {
                         // Mid-stream error — cache as trailers, return null message
+                        let (code, message) = status_to_php(&status, deadline_usec);
                         state.cached_trailers = Some(StreamTrailers {
-                            code: status.code() as i32,
-                            message: status.message().to_string(),
+                            code,
+                            message,
                             metadata: status_metadata_for_php(&status),
                         });
                         let mut null_zval = Zval::new();

--- a/test.sh
+++ b/test.sh
@@ -30,6 +30,7 @@ Commands:
   firestore   Run Firestore client compatibility test
   leak        Run memory leak test with local gRPC test server
   streaming   Run server streaming test with local gRPC test server
+  unary       Run split-batch unary test with local gRPC test server
   zts         Run ZTS stress test with FrankenPHP + concurrent requests
   temporal    Run Temporal SDK integration test (starts temporalio/auto-setup)
   otel        Run OpenTelemetry integration test (starts otel-collector)
@@ -100,6 +101,13 @@ cmd_streaming() {
     info "Running server streaming test"
     run_target test-streaming
     ok "Server streaming test passed"
+}
+
+cmd_unary() {
+    build_target test-unary
+    info "Running split-batch unary test"
+    run_target test-unary
+    ok "Split-batch unary test passed"
 }
 
 cmd_zts() {
@@ -210,6 +218,8 @@ cmd_all() {
     echo ""
     cmd_streaming
     echo ""
+    cmd_unary
+    echo ""
     cmd_leak
     echo ""
     ok "All tests passed"
@@ -227,6 +237,7 @@ case "$command" in
     firestore)   cmd_firestore ;;
     leak)        cmd_leak ;;
     streaming)   cmd_streaming ;;
+    unary)       cmd_unary ;;
     zts)         cmd_zts ;;
     temporal)    cmd_temporal ;;
     otel)        cmd_otel ;;

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -140,6 +140,15 @@ COPY tests/test_plugin_exception.php /app/tests/test_plugin_exception.php
 CMD ["sh", "-c", "grpc-test-server & sleep 1 && php tests/test_streaming.php && php tests/test_empty_response.php && php tests/test_plugin_exception.php"]
 
 # ---------------------------------------------------------------------------
+# Stage 9bb: Split-batch unary test runner (start() then wait())
+FROM test-base AS test-unary
+
+COPY --from=test-server-builder /build/target/release/grpc-test-server /usr/local/bin/grpc-test-server
+COPY tests/test_unary_split.php /app/tests/test_unary_split.php
+
+CMD ["sh", "-c", "grpc-test-server & sleep 1 && php tests/test_unary_split.php"]
+
+# ---------------------------------------------------------------------------
 # Stage 9c: Binary trailing metadata test runner
 FROM test-base AS test-binary-trailer
 

--- a/tests/server/proto/test.proto
+++ b/tests/server/proto/test.proto
@@ -7,6 +7,7 @@ service TestService {
   rpc EmptyResponse(Payload) returns (Empty);
   rpc LargeResponse(Payload) returns (Payload);
   rpc ErrorResponse(Payload) returns (Payload);
+  rpc SlowEcho(Payload) returns (Payload);
   rpc StreamEcho(Payload) returns (stream Payload);
   rpc CollectPayloads(stream Payload) returns (Payload);
   rpc BidiEcho(stream Payload) returns (stream Payload);

--- a/tests/server/src/main.rs
+++ b/tests/server/src/main.rs
@@ -9,6 +9,10 @@ pub mod pb {
 use pb::test_service_server::{TestService, TestServiceServer};
 use pb::{Empty, Payload};
 
+/// Per-call delay of the SlowEcho method. Kept in sync with the same constant
+/// in tests/test_unary_split.php.
+const SLOW_ECHO_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
+
 #[derive(Default)]
 pub struct TestServiceImpl;
 
@@ -31,6 +35,14 @@ impl TestService for TestServiceImpl {
 
     async fn empty_response(&self, _request: Request<Payload>) -> Result<Response<Empty>, Status> {
         Ok(Response::new(Empty {}))
+    }
+
+    /// Echo after a fixed delay, so a client can tell concurrent calls from
+    /// serialised ones: N calls take ~SLOW_ECHO_DELAY when they overlap and
+    /// ~N × SLOW_ECHO_DELAY when they do not.
+    async fn slow_echo(&self, request: Request<Payload>) -> Result<Response<Payload>, Status> {
+        tokio::time::sleep(SLOW_ECHO_DELAY).await;
+        Ok(Response::new(request.into_inner()))
     }
 
     async fn large_response(

--- a/tests/test_unary_split.php
+++ b/tests/test_unary_split.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Split-batch unary test — the pattern every generated PHP client uses:
+ * `UnaryCall::start()` issues a send-only startBatch, `wait()` issues the
+ * recv startBatch afterwards.
+ *
+ * Asserts that results match the single-batch form: message, initial metadata,
+ * trailing metadata, status codes, deadline and cancellation.
+ *
+ * Run:
+ *   # Terminal 1: cargo run --manifest-path tests/server/Cargo.toml
+ *   # Terminal 2: php tests/test_unary_split.php
+ */
+declare(strict_types=1);
+
+echo "=== Split-batch Unary Test ===\n\n";
+
+/** Matches SLOW_ECHO_DELAY in tests/server/src/main.rs. */
+const SLOW_ECHO_DELAY = 0.250;
+
+$tests = 0;
+$passed = 0;
+
+function check(string $name, bool $result, string $detail = ''): void {
+    global $tests, $passed;
+    $tests++;
+    if ($result) { $passed++; echo "  ✓ {$name}\n"; }
+    else { echo "  ✗ {$name}" . ($detail ? ": {$detail}" : '') . "\n"; }
+}
+
+function encode_varint(int $value): string {
+    $buf = '';
+    while ($value > 0x7f) {
+        $buf .= chr(($value & 0x7f) | 0x80);
+        $value >>= 7;
+    }
+    return $buf . chr($value & 0x7f);
+}
+
+function encode_payload(string $data): string {
+    if ($data === '') return '';
+    return "\x0a" . encode_varint(strlen($data)) . $data;
+}
+
+/** Issues the send batch only, exactly as UnaryCall::start() does. */
+function start_unary(Grpc\Channel $channel, string $method, string $body, ?Grpc\Timeval $deadline = null): Grpc\Call {
+    $call = new Grpc\Call($channel, $method, $deadline ?? Grpc\Timeval::infFuture());
+    $call->startBatch([
+        Grpc\OP_SEND_INITIAL_METADATA => [],
+        Grpc\OP_SEND_MESSAGE => ['message' => encode_payload($body)],
+        Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
+    ]);
+    return $call;
+}
+
+/** Issues the recv batch only, exactly as UnaryCall::wait() does. */
+function wait_unary(Grpc\Call $call): object {
+    return $call->startBatch([
+        Grpc\OP_RECV_INITIAL_METADATA => true,
+        Grpc\OP_RECV_MESSAGE => true,
+        Grpc\OP_RECV_STATUS_ON_CLIENT => true,
+    ]);
+}
+
+$target = 'localhost:50051';
+$channel = new Grpc\Channel($target, ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+
+// -----------------------------------------------------------------------------
+// Case 1: success — message plus binary initial metadata.
+// -----------------------------------------------------------------------------
+echo "--- Case 1: success response ---\n";
+
+$e = wait_unary(start_unary($channel, '/grpc.testing.TestService/Echo', 'hi'));
+check('status OK', ($e->status->code ?? -1) === 0, 'code=' . ($e->status->code ?? -1));
+check('message echoed', ($e->message ?? '') === encode_payload('hi'));
+check(
+    'binary initial metadata intact',
+    ($e->metadata['x-test-binary-bin'][0] ?? null) === "hello\x00\xfftrailer"
+);
+
+// -----------------------------------------------------------------------------
+// Case 2: error status — code, details and binary trailing metadata.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 2: error response ---\n";
+
+$e = wait_unary(start_unary($channel, '/grpc.testing.TestService/ErrorResponse', 'x'));
+check('status INTERNAL (13)', ($e->status->code ?? -1) === 13, 'code=' . ($e->status->code ?? -1));
+check('status details preserved', ($e->status->details ?? '') === 'test error');
+check(
+    'rich-status trailer intact',
+    ($e->status->metadata['grpc-status-details-bin'][0] ?? null) === "hello\x00\xfftrailer"
+);
+check('message is null on error', property_exists($e, 'message') && $e->message === null);
+
+// -----------------------------------------------------------------------------
+// Case 3: empty response body — must be "" like the C extension, not null.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 3: empty response ---\n";
+
+$e = wait_unary(start_unary($channel, '/grpc.testing.TestService/EmptyResponse', 'x'));
+check('status OK', ($e->status->code ?? -1) === 0, 'code=' . ($e->status->code ?? -1));
+check('message is empty string, not null', ($e->message ?? null) === '');
+
+// -----------------------------------------------------------------------------
+// Case 4: 64KB response body.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 4: large response ---\n";
+
+$e = wait_unary(start_unary($channel, '/grpc.testing.TestService/LargeResponse', 'x'));
+check('status OK', ($e->status->code ?? -1) === 0, 'code=' . ($e->status->code ?? -1));
+check('64KB body received', strlen($e->message ?? '') > 65536, strlen($e->message ?? '') . ' bytes');
+
+// -----------------------------------------------------------------------------
+// Case 5: unknown method — status must surface on the recv batch.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 5: unknown method ---\n";
+
+$e = wait_unary(start_unary($channel, '/grpc.testing.TestService/NoSuchMethod', 'x'));
+check('status UNIMPLEMENTED (12)', ($e->status->code ?? -1) === 12, 'code=' . ($e->status->code ?? -1));
+
+// -----------------------------------------------------------------------------
+// Case 6: deadline — set on the send batch, enforced against the slow method.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 6: deadline ---\n";
+
+$deadline = Grpc\Timeval::now()->add(new Grpc\Timeval(50 * 1000)); // 50ms < SLOW_ECHO_DELAY
+$e = wait_unary(start_unary($channel, '/grpc.testing.TestService/SlowEcho', 'hi', $deadline));
+check('status DEADLINE_EXCEEDED (4)', ($e->status->code ?? -1) === 4, 'code=' . ($e->status->code ?? -1));
+
+// -----------------------------------------------------------------------------
+// Case 7: cancellation between start and wait.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 7: cancel before wait ---\n";
+
+$call = start_unary($channel, '/grpc.testing.TestService/Echo', 'hi');
+$call->cancel();
+try {
+    $e = wait_unary($call);
+    check('cancelled call is not OK', ($e->status->code ?? -1) !== 0, 'code=' . ($e->status->code ?? -1));
+} catch (Throwable $t) {
+    check('cancelled call is not OK', true);
+}
+
+// -----------------------------------------------------------------------------
+echo "\n=== {$passed}/{$tests} tests passed ===\n";
+exit($passed === $tests ? 0 : 1);

--- a/tests/test_unary_split.php
+++ b/tests/test_unary_split.php
@@ -4,8 +4,15 @@
  * `UnaryCall::start()` issues a send-only startBatch, `wait()` issues the
  * recv startBatch afterwards.
  *
- * Asserts that results match the single-batch form: message, initial metadata,
- * trailing metadata, status codes, deadline and cancellation.
+ * Two things are asserted:
+ *
+ *   1. Results match the single-batch form (message, initial metadata,
+ *      trailing metadata, status, deadline, cancellation).
+ *   2. Calls started before any of them is awaited overlap on the wire.
+ *      Buffering the request until the recv batch makes a batch of N calls
+ *      cost N round trips instead of one, which is what
+ *      https://github.com/BSN4/grpc-php-rs/issues/18 reported: 100 products
+ *      through the Merchant API took 100-130s instead of 2-5s.
  *
  * Run:
  *   # Terminal 1: cargo run --manifest-path tests/server/Cargo.toml
@@ -140,6 +147,49 @@ try {
 } catch (Throwable $t) {
     check('cancelled call is not OK', true);
 }
+
+// -----------------------------------------------------------------------------
+// Case 8: concurrency — the regression this file exists for.
+//
+// Ten calls against a method that sleeps SLOW_ECHO_DELAY server-side. If the
+// requests go out during start(), the whole batch costs about one delay; if
+// they are buffered until wait(), it costs ten. The threshold sits far from
+// both so a loaded CI runner cannot flip it.
+// -----------------------------------------------------------------------------
+echo "\n--- Case 8: concurrent calls overlap ---\n";
+
+$n = 10;
+$serial = $n * SLOW_ECHO_DELAY;
+$budget = $serial / 2;
+
+$calls = [];
+$t0 = microtime(true);
+for ($i = 0; $i < $n; $i++) {
+    $calls[] = start_unary($channel, '/grpc.testing.TestService/SlowEcho', "msg{$i}");
+}
+$startPhase = microtime(true) - $t0;
+
+$correct = 0;
+foreach ($calls as $i => $call) {
+    $e = wait_unary($call);
+    if (($e->status->code ?? -1) === 0 && ($e->message ?? '') === encode_payload("msg{$i}")) {
+        $correct++;
+    }
+}
+$total = microtime(true) - $t0;
+
+printf("  %d calls, %.2fs total (serialised would be ~%.2fs)\n", $n, $total, $serial);
+check("all {$n} responses correct and in order", $correct === $n, "{$correct}/{$n}");
+check(
+    sprintf('batch completed in under %.2fs', $budget),
+    $total < $budget,
+    sprintf('took %.2fs', $total)
+);
+check(
+    'start() does not block on the response',
+    $startPhase < SLOW_ECHO_DELAY,
+    sprintf('start phase took %.2fs', $startPhase)
+);
 
 // -----------------------------------------------------------------------------
 echo "\n=== {$passed}/{$tests} tests passed ===\n";


### PR DESCRIPTION
## Problem

Awaiting a batch of unary calls costs one full round trip per call instead of overlapping them. Reported in #18 against the Google Merchant Products API: 100 products took 100-130s where ext-grpc takes 2-5s, scaling linearly with the batch size (10 products: 10-12s, 50 products: 50-60s).

This hits every `google-cloud-php` client, because `Utils::settle($promises)->wait()` is the documented way to send a batch: each promise is started first, then all of them are awaited.

## Cause

A generated PHP client issues a unary call as two batches. `UnaryCall::start()` sends `SEND_INITIAL_METADATA + SEND_MESSAGE + SEND_CLOSE_FROM_CLIENT`, and `UnaryCall::wait()` sends the recv ops afterwards.

The send batch only buffered the request into `pending_metadata` / `pending_message` and returned. Nothing reached the wire until the recv batch, which then ran the entire RPC inside `rt.block_on`. So the calls could never overlap: each `wait()` completed a full round trip before the next one began. Under ext-grpc the request goes out during `start()` and the completion queue carries it, so all of them are in flight while the waits are collected.

Measured against a test server that sleeps 500ms per call, with the client starting all calls before awaiting any:

| calls | before | after | ext-grpc |
|---|---|---|---|
| 10 | 5.01s | 0.50s | 0.50s |
| 40 | 20.04s | 0.51s | 0.51s |
| 100 | 50.10s | 0.52s | 0.52s |

Server-side peak concurrency went from 1 request in flight to 40 (at 40 calls), matching ext-grpc.

## Fix

A send batch carrying `SEND_CLOSE_FROM_CLIENT` is a complete request, so it now starts the tonic call immediately and the recv batch reads the response out of it.

`UnaryCall::start()` and `ServerStreamingCall::start()` emit the same batch shape and cannot be told apart at that point, so both take the streaming path. A unary recv batch then just reads one message plus trailers, which `build_stream_result` already handled. `execute_call` stays for the single-batch form, where every op arrives in one `startBatch` and there is nothing to overlap.

Two supporting changes:

- `start_server_stream` no longer awaits response headers before returning. Blocking there for a round trip would serialise the calls again.
- The recv path resolves headers, message and trailers in a single `block_on` instead of three, since each one costs a park/wake round trip. The mid-stream error case hands its trailers receiver back untouched, because a task that reports an error through the message channel may never send trailers.

### Second commit: DEADLINE_EXCEEDED

Writing the tests surfaced a separate compatibility bug, so it is a separate commit and can be dropped independently.

tonic maps its `TimeoutExpired` error to `CANCELLED "Timeout expired"` and drops the source, so a call that ran past its deadline surfaced to PHP as status 1 where ext-grpc reports 4 `"Deadline Exceeded"`. Callers branch on that code: `google/gax` retries DEADLINE_EXCEEDED and gives up on CANCELLED, so the mismatch turns a retryable timeout into a hard failure. This affected both the single-batch and split-batch forms.

A CANCELLED status arriving after the deadline set on the request is now reported as DEADLINE_EXCEEDED. Cancellation through `Call::cancel()` is answered from the cancellation token and never passes through this mapping, so an explicit cancel still reports CANCELLED.

## Tests

Adds `tests/test_unary_split.php`, wired up as the `test-unary` Docker stage and a `./test.sh unary` command, and included in `./test.sh all` so CI runs it.

The split send/recv batch pattern had no coverage at all: every existing test issues all ops in a single `startBatch`. The new file covers success with binary initial metadata, error status with a rich-status trailer, empty body, 64KB body, unknown method, deadline, cancel between start and wait, and the concurrency regression itself.

The test server gains a `SlowEcho` method that sleeps 250ms, so ten calls cost about one delay when they overlap and ten when they do not. The assertion trips at half the serialised time, far from either outcome, so a loaded runner cannot flip it.

It is a real regression detector rather than documentation: against 0.2.9 the file scores 15/17, failing exactly the deadline code and the 2.52s batch; against this branch and against the official C extension it scores 17/17 with the batch at 0.25s.

## Verification

From a clean checkout: `cargo build --release`, `cargo test --release` (10/10), `cargo clippy -- -D warnings` clean.

Docker targets, all green: `test-smoke` 53/53, `test-unary` 17/17, `test-streaming` 5/5, `test-binary-trailer` 10/10, `test-leak` (no growth over 20k iterations), `test-compat` 6/6, `test-grpc-gcp` 36/36.

`test-binary-trailer` at 10/10 is the meaningful cross-check for the rebase onto 0.2.9: the rich-status Case 3 added in #17 drives a server-streaming call that errors after response headers using the split batch shape, which is exactly the path this PR reroutes.

Sequential single calls are unaffected: 3000 back-to-back calls measured 1.16-1.35s before and 1.16-1.38s after, three runs each. Both intermediate commits build and pass on their own, so bisect stays green.

## Not addressed here

- The env vars mentioned in #18 (`GRPC_EXPERIMENTAL_MAX_CONCURRENT_STREAMS_CONNECTION_SCALING`, `GRPC_EXPERIMENTS`) remain unsupported. They scale connections when one exceeds `MAX_CONCURRENT_STREAMS`, which was never the constraint here, since the client held at most one stream open. A caller batching beyond roughly 100 concurrent streams will still queue on a single tonic `Channel` where ext-grpc opens more subchannels. That is a separate and much higher ceiling.
- `CallCredentials` plugin callbacks still run on the PHP thread at `start()`, one after another. That is unavoidable under TSRM and harmless while the auth library serves cached tokens, but a plugin fetching a token per call would still serialise.